### PR TITLE
Fix color of a-tags when logged in (dark mode)

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -436,6 +436,12 @@ img
     font-weight: 600 !important;
 }
 
+.mod-cta a
+{
+    color: var(--background-secondary-alt) !important;
+    font-weight: 600 !important;
+} 
+
 .mod-cta:hover
 {
     background-color: var(--interactive-before) !important;


### PR DESCRIPTION
When logged in, you can't see the text within two of the buttons. This change solves the issue by making the text darker