### PR TITLE
Remove forceful img attributes

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -246,13 +246,6 @@ thead
     border-top-right-radius: 0 !important;
 }
 
-img
-{
-    display: block !important;
-    margin-left: auto !important;
-    margin-right: auto !important;
-}
-
 .HyperMD-list-line
 {
     padding-top: 0 !important;


### PR DESCRIPTION
Hi insanum,

Some users are getting incompatibilities between my emoji plugin and themes that force all images to be centered an in-line. Are you happy to remove this as I can't do anything from my side because of the !important flag.