### PR TITLE
Makes empty-state-action class switch to interactive accent on hover 

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -422,6 +422,11 @@ img
     border: 5px solid var(--interactive-accent) !important;
 }
 
+.empty-state-action:hover
+{
+    color: var(--interactive-accent);
+}
+
 .checkbox-container
 {
     background-color: var(--interactive-before);


### PR DESCRIPTION
Fix for #17 