### PR TITLE
Fix heading sizes looking oversized in edit mode

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -398,7 +398,11 @@ thead
     margin-right: 10px !important;
 }
 
-.cm-header-1,
+.cm-header {
+    font-weight: 500 !important;
+}
+
+.HyperMD-header-1,
 .markdown-preview-section h1
 {
     font-weight: 500 !important;
@@ -406,7 +410,7 @@ thead
     color: var(--text-title-h1) !important;
 }
 
-.cm-header-2,
+.HyperMD-header-2,
 .markdown-preview-section h2
 {
     font-weight: 500 !important;
@@ -414,7 +418,7 @@ thead
     color: var(--text-title-h2) !important;
 }
 
-.cm-header-3,
+.HyperMD-header-3,
 .markdown-preview-section h3
 {
     font-weight: 500 !important;
@@ -422,7 +426,7 @@ thead
     color: var(--text-title-h3) !important;
 }
 
-.cm-header-4,
+.HyperMD-header-4,
 .markdown-preview-section h4
 {
     font-weight: 500 !important;
@@ -430,7 +434,7 @@ thead
     color: var(--text-title-h4) !important;
 }
 
-.cm-header-5,
+.HyperMD-header-5,
 .markdown-preview-section h5
 {
     font-weight: 500 !important;
@@ -438,7 +442,7 @@ thead
     color: var(--text-title-h5) !important;
 }
 
-.cm-header-6,
+.HyperMD-header-6,
 .markdown-preview-section h6
 {
     font-weight: 500 !important;


### PR DESCRIPTION
An update to how heading sizes are styled in `v0.13.27` saw heading font sizes move from cm-header-x to HyperMD-header-x.

This resulted in `cm-header-x` font sizes showing up as huge in editing mode. The style has now been changed to `.HyperMD-header-x`. (reported in #22)

For the weight to look correct though, a separate rule for `.cm-header` had to be created