### PR TITLE
Ensure headers with links are colorized

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -398,6 +398,40 @@ thead
     margin-right: 10px !important;
 }
 
+.cm-header-1.cm-link,
+h1 a
+{
+    color: var(--text-title-h1) !important;
+}
+
+.cm-header-2.cm-link,
+h2 a
+{
+    color: var(--text-title-h2) !important;
+}
+
+.cm-header-3.cm-link,
+h3 a
+{
+    color: var(--text-title-h3) !important;
+}
+.cm-header-4.cm-link,
+h4 a
+{
+    color: var(--text-title-h4) !important;
+}
+.cm-header-5.cm-link,
+h5 a
+{
+    color: var(--text-title-h5) !important;
+}
+.cm-header-6.cm-link,
+h6 a
+{
+    color: var(--text-title-h6) !important;
+}
+
+
 .cm-header-1,
 .markdown-preview-section h1
 {


### PR DESCRIPTION
Currently, if a header links to a URL, it gets turned to an orange shade (`--text-a`). I don't know if this behaviour is expected or if it changed due to recent updates.

This is a matter of preference, but I think it's nicer if the colour matches the original header colour.

This update, ensures that in both editing and preview mode, the link styling respects the header colour.\

**This is what it looks like without styling**

Reading mode:

![image](https://user-images.githubusercontent.com/208123/156503927-fd58ceea-6e46-4061-8909-01390b4923b4.png)

Editing mode:

![image](https://user-images.githubusercontent.com/208123/156504012-3b9f4b58-3dfd-4a67-a140-6712fca6ab83.png)

**With styling**

Reading mode:

![image](https://user-images.githubusercontent.com/208123/156504060-498b83c9-5c42-4b9b-9cb0-50a8de1f27b9.png)

Editing mode:

![image](https://user-images.githubusercontent.com/208123/156504078-36e646ad-9c1c-4252-a415-adf163c4bbba.png)

---

Feel free to close the PR if the colours don't feel right though.