### PR TITLE
feat: add Gruvbox-themed callouts

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -553,3 +553,27 @@ pre[class*="language-"]
     color: var(--bright-red);
 }
 
+body {
+    --callout-border-width: 1px;
+    --callout-border-opacity: 0.4;
+    /* Order as defined in app.css */
+    --callout-default: var(--neutral-blue_x);
+    --callout-note: var(--neutral-blue_x);
+    --callout-summary: var(--neutral-aqua_x);
+    --callout-info: var(--neutral-blue_x);
+    --callout-todo: var(--neutral-blue_x);
+    --callout-important: var(--neutral-aqua_x);
+    --callout-tip: var(--neutral-aqua_x);
+    --callout-success: var(--neutral-green_x);
+    --callout-question: var(--neutral-yellow_x);
+    --callout-warning: var(--neutral-orange_x);
+    --callout-fail: var(--neutral-red_x);
+    --callout-error: var(--neutral-red_x);
+    --callout-bug: var(--neutral-red_x);
+    --callout-example: var(--neutral-purple_x);
+    --callout-quote: var(--gray_x);
+}
+
+.callout {
+    background-color: rgba(var(--callout-color), 0.2);
+}


### PR DESCRIPTION
Picking up the work from #29:

- define callouts in a theme-agnostic way, but kept colours in line with the callout colours from the original Obsidian theme
- callouts have a small border
- dropped the drop shadow since it distracted more visually than it supported

I played around with opacity of `0.3` for `background-color` and `0.5` for `--callout-border-opacity` but it becomes too bright for the dark theme.

These are the resulting unique looks (hope the colours come through correctly, my Firefox is currently displaying this as more faded than it in fact is, going to check colour management after posting this).
Edit: OK, think I fixed the colour disparity.
Edit 2: attempt 2 at the colour disparity fixing.

Dark
![dark](https://github.com/insanum/obsidian_gruvbox/assets/610865/d97974d1-82d7-44c4-8666-000b352da2a1)

Light
![light](https://github.com/insanum/obsidian_gruvbox/assets/610865/bc128b9d-6fe2-4f73-96fb-2a326bb3b025)
