### PR TITLE
fix: adds gray color for code comments

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -406,6 +406,11 @@ pre[class*="language-"]
     line-height: var(--line-height-tight) !important;
 }
 
+/* Missing Comments Color in Code Blocks */
+.cm-comment {
+    color: var(--gray)
+}
+
 .cm-url
 {
     color: var(--link-url) !important;


### PR DESCRIPTION
Adds a separate gray color for comments in code blocks which otherwise rendered in bright white color in dark mode.